### PR TITLE
Use SWIG_as_voidptr template in C++ only

### DIFF
--- a/Lib/typemaps/swigmacros.swg
+++ b/Lib/typemaps/swigmacros.swg
@@ -140,12 +140,12 @@ nocppval
 #define %as_voidptrptr(a)            SWIG_as_voidptrptr(a)
 
 %insert("header") {
-//%define_as(SWIG_as_voidptr(a),    %const_cast(%static_cast(a,const void *), void *))
+#if defined(__cplusplus)
 template<typename T>
-inline void *SWIG_as_voidptr(T *a)
-{
-    return const_cast< void * >(static_cast< const void * >(a));
-}
+inline void *SWIG_as_voidptr(T *a) { return const_cast<void *>(static_cast<const void *>(a)); }
+#else
+%define_as(SWIG_as_voidptr(a),    %const_cast(%static_cast(a,const void *), void *))
+#endif
 
 %define_as(SWIG_as_voidptrptr(a), ((void)%as_voidptr(*a),%reinterpret_cast(a, void**)))
 }


### PR DESCRIPTION
Use macro for C compiler. This was causing fails for projects
using non-C++-enabled wrappers.

Signed-off-by: Mika Korhonen <mika.j.korhonen@gmail.com>